### PR TITLE
Remove redundant import rules from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,18 +97,6 @@ atlas_user:
   safe_to_delete: false    # Whether to delete users from Atlas on K8s resource deletion
 ```
 
-## Code Style
-
-- **Imports**: Do not merge imports. Each import should be on its own line.
-  ```rust
-  // Good
-  use crate::atlas::AtlasUserContext;
-  use crate::atlas::AtlasUserRepository;
-
-  // Bad
-  use crate::atlas::{AtlasUserContext, AtlasUserRepository};
-  ```
-
 ## Dependencies
 
 - **kuberator v0.3.2**: Kubernetes operator framework


### PR DESCRIPTION
## Summary
- Remove redundant import rules from project CLAUDE.md — now covered by global `~/.claude/rules/rust.md`

## Test plan
- [ ] Verify Claude Code still picks up Rust conventions when working in this repo